### PR TITLE
Batch conversion support and general fixes

### DIFF
--- a/HEIF/main.swift
+++ b/HEIF/main.swift
@@ -9,7 +9,8 @@ let kToolVersion = "0.4"
 
 // Options parsed from command line.
 let kCompressionQualityOption = "-q="
-var compressionQuality = 0.76
+let defaultCompressionQuality = 0.76
+var compressionQuality = defaultCompressionQuality
 
 // Fills options and returns input image file.
 // OR prints usage and exits if input file wasn't specified.
@@ -30,7 +31,7 @@ func ParseCommandLine() -> URL {
     let kBinaryName = URL(fileURLWithPath:CommandLine.arguments[0]).lastPathComponent
     print("Converts image to HEIC format, version \(kToolVersion)")
     print("Usage: \(kBinaryName) [\(kCompressionQualityOption)quality] <image>")
-    print("Default quality is \(compressionQuality) and it ranges from 0.1 (max compression) to 1.0 (lossless).")
+    print("Default quality is \(defaultCompressionQuality) and it ranges from 0.1 (max compression) to 1.0 (lossless).")
     print("Please note: odd image dimensions will be truncated by codec to even ones.")
     exit(0)
   }

--- a/HEIF/main.swift
+++ b/HEIF/main.swift
@@ -5,7 +5,7 @@
 import Foundation
 import CoreImage
 
-let kToolVersion = "0.4"
+let kToolVersion = "0.5"
 
 // Options parsed from command line.
 let kCompressionQualityOption = "-q="

--- a/HEIF/main.swift
+++ b/HEIF/main.swift
@@ -5,7 +5,7 @@
 import Foundation
 import CoreImage
 
-let kToolVersion = 0.4
+let kToolVersion = "0.4"
 
 // Options parsed from command line.
 let kCompressionQualityOption = "-q="

--- a/HEIF/main.swift
+++ b/HEIF/main.swift
@@ -14,8 +14,8 @@ var compressionQuality = defaultCompressionQuality
 
 // Fills options and returns input image file.
 // OR prints usage and exits if input file wasn't specified.
-func ParseCommandLine() -> URL {
-  var imagePath:String?
+func ParseCommandLine() -> [URL] {
+  var urls: [URL] = []
   for i in 1..<Int(CommandLine.argc) {
     let arg = CommandLine.arguments[i]
     if arg.hasPrefix(kCompressionQualityOption) {
@@ -24,10 +24,10 @@ func ParseCommandLine() -> URL {
         print("Apple's compressor will use some internal default quality level, empirically it is 0.76-0.77")
       }
     } else {
-      imagePath = arg
+      urls.append(URL(fileURLWithPath:arg))
     }
   }
-  if imagePath == nil {
+  if urls.count == 0 {
     let kBinaryName = URL(fileURLWithPath:CommandLine.arguments[0]).lastPathComponent
     print("Converts image to HEIC format, version \(kToolVersion)")
     print("Usage: \(kBinaryName) [\(kCompressionQualityOption)quality] <image>")
@@ -35,17 +35,20 @@ func ParseCommandLine() -> URL {
     print("Please note: odd image dimensions will be truncated by codec to even ones.")
     exit(0)
   }
-  return URL(fileURLWithPath:imagePath!)
+  return urls
 }
 
-let imageUrl = ParseCommandLine()
-let image = CIImage(contentsOf: imageUrl)
-let context = CIContext(options: nil)
-let heicUrl = imageUrl.deletingPathExtension().appendingPathExtension("heic")
-let options = NSDictionary(dictionary: [kCGImageDestinationLossyCompressionQuality:compressionQuality])
+let imageUrls = ParseCommandLine()
 
-try! context.writeHEIFRepresentation(of:image!,
-                        to:heicUrl,
-                        format: CIFormat.ARGB8,
-                        colorSpace: image!.colorSpace!,
-                        options:options as! [CIImageRepresentationOption : Any])
+for imageUrl in imageUrls {
+  let image = CIImage(contentsOf: imageUrl)
+  let context = CIContext(options: nil)
+  let heicUrl = imageUrl.deletingPathExtension().appendingPathExtension("heic")
+  let options = NSDictionary(dictionary: [kCGImageDestinationLossyCompressionQuality:compressionQuality])
+
+  try! context.writeHEIFRepresentation(of:image!,
+                          to:heicUrl,
+                          format: CIFormat.ARGB8,
+                          colorSpace: image!.colorSpace!,
+                          options:options as! [CIImageRepresentationOption : Any])
+}


### PR DESCRIPTION
The patch adds batch conversion support with bug fixes.

In the old version, when quality is specified but not any images, default quality displayed in help messages is wrong.
