### PR TITLE
fix colorspace's problem

### DIFF
--- a/HEIF/main.swift
+++ b/HEIF/main.swift
@@ -46,9 +46,10 @@ for imageUrl in imageUrls {
   let heicUrl = imageUrl.deletingPathExtension().appendingPathExtension("heic")
   let options = NSDictionary(dictionary: [kCGImageDestinationLossyCompressionQuality:compressionQuality])
 
+  let colorSpace = image!.colorSpace!.model == .rgb ? image!.colorSpace! : CGColorSpaceCreateDeviceRGB()
   try! context.writeHEIFRepresentation(of:image!,
                           to:heicUrl,
                           format: CIFormat.ARGB8,
-                          colorSpace: image!.colorSpace!,
+                          colorSpace: colorSpace,
                           options:options as! [CIImageRepresentationOption : Any])
 }


### PR DESCRIPTION
when convert a jpg(or others, **colorspace is GRAY**). will raise an exception.
example:
use these python code to convert a normal pic to gray colorspace.
`from PIL import Image

image = Image.open("image.jpg")

gray_image = image.convert("L")

gray_image.save("gray_image.jpg")`
then use HEIF
./HEIF gray_image.jpg

so we need use default colorspace ( I think rgb ) is suitable when colorspace is not supported.